### PR TITLE
[#5] 루트 레이아웃 max-width 설정

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -27,7 +27,9 @@ export default function RootLayout({
           href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css"
         />
       </head>
-      <body className={`${pretendard.className} max-w-[430px] m-auto`}>{children}</body>
+      <body className={`${pretendard.className}`}>
+        <div className="m-auto max-w-[430px]">{children}</div>
+      </body>
     </html>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,8 +10,8 @@ const pretendard = localFont({
 });
 
 export const metadata: Metadata = {
-  title: "토실토싱",
-  description: "실시간 타이머를 이용한 계획 웹",
+  title: "토실토실",
+  description: "실시간 타이머를 이용한 목표 달성",
 };
 
 export default function RootLayout({
@@ -27,7 +27,7 @@ export default function RootLayout({
           href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css"
         />
       </head>
-      <body className={`${pretendard.className}`}>{children}</body>
+      <body className={`${pretendard.className} max-w-[430px] m-auto`}>{children}</body>
     </html>
   );
 }


### PR DESCRIPTION
## 📄 Summary
- 루트 레이아웃에 max-width 적용
>

## 🙋🏻 More

>


close #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - 본문 레이아웃이 최대 430px로 제한되고 중앙 정렬되어, 콘텐츠가 더 보기 좋게 표시됩니다.

- **Documentation**
  - 사이트 제목이 "토실토싱"에서 "토실토실"로 변경되고, 설명이 목표 달성에 초점을 맞춘 내용으로 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->