### PR TITLE
Form을 react-hook-form으로 마이그레이션

### DIFF
--- a/app/(auth)/find-password/page.tsx
+++ b/app/(auth)/find-password/page.tsx
@@ -1,7 +1,5 @@
 import RequestCodeForm from "@/components/auth/form/RequestCodeForm";
-import VerifyCodeForm from "@/components/auth/form/VerifyCodeForm";
 
 export default function FindPasswordPage() {
-  const isAuthCodeSent = true;
-  return <div>{isAuthCodeSent ? <RequestCodeForm /> : <VerifyCodeForm />}</div>;
+  return <RequestCodeForm />;
 }

--- a/app/(auth)/find-password/reset/page.tsx
+++ b/app/(auth)/find-password/reset/page.tsx
@@ -1,9 +1,5 @@
 import ResetPasswordForm from "@/components/auth/form/ResetPasswordForm";
 
 export default function ResetPasswordPage() {
-  return (
-    <div>
-      <ResetPasswordForm />
-    </div>
-  );
+  return <ResetPasswordForm />;
 }

--- a/app/(auth)/find-password/verify/page.tsx
+++ b/app/(auth)/find-password/verify/page.tsx
@@ -1,0 +1,5 @@
+import VerifyCodeForm from "@/components/auth/form/VerifyCodeForm";
+
+export default function VerifyCodePage() {
+  return <VerifyCodeForm />;
+}

--- a/components/auth/form/LoginForm.tsx
+++ b/components/auth/form/LoginForm.tsx
@@ -51,6 +51,7 @@ const LoginForm = () => {
           render={({ field }) => (
             <PasswordInput
               sort="login"
+              isValid={!!errors.password}
               name={field.name}
               value={field.value}
               errorMessage={errors.password?.message}

--- a/components/auth/form/LoginForm.tsx
+++ b/components/auth/form/LoginForm.tsx
@@ -1,87 +1,82 @@
 "use client";
 
-import { useState } from "react";
 import Link from "next/link";
-import { z } from "zod";
-import { useFormValidate } from "@/hooks/useFormValidate";
 import EmailInput from "@/components/auth/input/EmailInput";
 import PasswordInput from "@/components/auth/input/PasswordInput";
 import PrimaryButton from "@/components/commons/button/PrimaryButton";
-import { loginSchema } from "@/schemas/auth";
-
-type LoginFormData = z.infer<typeof loginSchema>;
+import { LoginFormData, loginSchema } from "@/schemas/auth";
+import { Controller, useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
 
 const LoginForm = () => {
-  const [formData, setFormData] = useState<LoginFormData>({
-    email: "",
-    password: "",
+  const {
+    control,
+    handleSubmit,
+    formState: { errors, isValid, isSubmitting },
+  } = useForm<LoginFormData>({
+    resolver: zodResolver(loginSchema),
+    mode: "onSubmit",
+    defaultValues: {
+      email: "",
+      password: "",
+    },
   });
 
-  const { errors: formErrors, validateField } =
-    useFormValidate<LoginFormData>(loginSchema);
-
-  const handleInputChange = (name: keyof LoginFormData, value: string) => {
-    setFormData((prev) => ({
-      ...prev,
-      [name]: value,
-    }));
-
-    validateField(name, value);
+  const onSubmit = (data: LoginFormData) => {
+    console.log("로그인 시도:", data);
+    // TODO: 로그인 API 호출 등
   };
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-
-    const parsed = loginSchema.safeParse(formData);
-
-    if (!parsed.success) {
-      const flattened = parsed.error.flatten().fieldErrors;
-      console.log("유효성 검사 실패", flattened);
-      return;
-    }
-
-    console.log("로그인 시도:", formData);
-  };
-
-  const isFormValid =
-    Object.values(formErrors ?? {}).every((error) => !error) &&
-    Object.values(formData).every((value) => value !== "");
 
   return (
-    <form onSubmit={handleSubmit}>
+    <form onSubmit={handleSubmit(onSubmit)}>
       <div className="mb-[43px] flex flex-col gap-[27px]">
         <h1 className="title2 mt-[128px] text-center">로그인</h1>
-        <EmailInput
+        <Controller
           name="email"
-          value={formData.email}
-          errorMessage={formErrors?.email?.[0]}
-          onInputChange={handleInputChange}
+          control={control}
+          render={({ field }) => (
+            <EmailInput
+              sort="login"
+              isValid={!!errors.email}
+              value={field.value}
+              errorMessage={errors.email?.message}
+              onInputChange={field.onChange}
+            />
+          )}
         />
-        <PasswordInput
+
+        <Controller
           name="password"
-          value={formData.password}
-          errorMessage={formErrors?.password?.[0]}
-          onInputChange={handleInputChange}
+          control={control}
+          render={({ field }) => (
+            <PasswordInput
+              sort="login"
+              name={field.name}
+              value={field.value}
+              errorMessage={errors.password?.message}
+              onInputChange={field.onChange}
+            />
+          )}
         />
       </div>
       <PrimaryButton
         type="submit"
         size="main"
         text="로그인"
-        isActive={isFormValid}
+        isActive={isValid && !isSubmitting}
       />
       <div className="mt-[27px] flex justify-between">
         <Link
           href="/find-password"
           className="subhead2 border-primary-deepGray text-primary-deepGray border-b-1 px-[6px] pb-[5px]"
         >
-          <p className="inline">비밀번호찾기</p>
+          비밀번호찾기
         </Link>
         <Link
           href="/signup"
           className="subhead2 border-primary-deepGray text-primary-deepGray border-b-1 px-[6px] pb-[5px]"
         >
-          <p className="inline">회원가입</p>
+          회원가입
         </Link>
       </div>
     </form>

--- a/components/auth/form/LoginForm.tsx
+++ b/components/auth/form/LoginForm.tsx
@@ -37,7 +37,7 @@ const LoginForm = () => {
           render={({ field }) => (
             <EmailInput
               sort="login"
-              isValid={!!errors.email}
+              isValid={!errors.email}
               value={field.value}
               errorMessage={errors.email?.message}
               onInputChange={field.onChange}
@@ -51,7 +51,7 @@ const LoginForm = () => {
           render={({ field }) => (
             <PasswordInput
               sort="login"
-              isValid={!!errors.password}
+              isValid={!errors.password}
               name={field.name}
               value={field.value}
               errorMessage={errors.password?.message}

--- a/components/auth/form/RequestCodeForm.tsx
+++ b/components/auth/form/RequestCodeForm.tsx
@@ -32,7 +32,7 @@ const RequestCodeForm = () => {
             <div className="mb-[37px] flex flex-col gap-[78px]">
               <h1 className="title2 mt-[163px] text-center">비밀번호 찾기</h1>
               <EmailInput
-                isValid={!!errors.email}
+                isValid={!errors.email}
                 value={field.value}
                 errorMessage={errors.email?.message}
                 onInputChange={field.onChange}

--- a/components/auth/form/RequestCodeForm.tsx
+++ b/components/auth/form/RequestCodeForm.tsx
@@ -1,56 +1,51 @@
 "use client";
 
-import { useState } from "react";
 import EmailInput from "@/components/auth/input/EmailInput";
 import PrimaryButton from "@/components/commons/button/PrimaryButton";
-import { AUTH_ERROR_MESSAGE } from "@/constants/authErrorMessage";
+import { RequestCodeFormData, requestCodeSchema } from "@/schemas/auth";
+import { Controller, useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
 
 const RequestCodeForm = () => {
-  const [formData, setFormData] = useState({
-    email: "",
+  const {
+    control,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<RequestCodeFormData>({
+    resolver: zodResolver(requestCodeSchema),
+    mode: "onChange",
+    defaultValues: { email: "" },
   });
 
-  const [formErrors, setFormErrors] = useState({
-    email: "",
-  });
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    console.log("인증번호 요청 Form: ", formData);
-  };
-
-  const handleInputChange = (name: string, value: string) => {
-    setFormData((prev) => ({
-      ...prev,
-      [name]: value,
-    }));
-
-    // 유효성 검사
-    if (name === "email") {
-      const isValidEmail = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
-      setFormErrors((prev) => ({
-        ...prev,
-        email: isValidEmail ? "" : AUTH_ERROR_MESSAGE.EMAIL,
-      }));
-    }
+  const onSubmit = (data: RequestCodeFormData) => {
+    console.log("인증번호 요청 Form:", data);
+    // TODO: 인증번호 요청 API 호출
   };
 
   return (
-    <form onSubmit={handleSubmit}>
-      <div className="mb-[37px] flex flex-col gap-[78px]">
-        <h1 className="title2 mt-[163px] text-center">비밀번호 찾기</h1>
-        <EmailInput
-          name="email"
-          value={formData.email}
-          errorMessage={formErrors.email}
-          onInputChange={handleInputChange}
-        />
-      </div>
-      <PrimaryButton
-        size="main"
-        text="인증번호 받기"
-        isActive={false}
-        onButtonClick={() => {}}
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <Controller
+        name="email"
+        control={control}
+        render={({ field }) => (
+          <>
+            <div className="mb-[37px] flex flex-col gap-[78px]">
+              <h1 className="title2 mt-[163px] text-center">비밀번호 찾기</h1>
+              <EmailInput
+                isValid={!!errors.email}
+                value={field.value}
+                errorMessage={errors.email?.message}
+                onInputChange={field.onChange}
+                sort="find-password"
+              />
+            </div>
+            <PrimaryButton
+              size="main"
+              text="인증번호 받기"
+              isActive={!!field.value && !errors.email}
+            />
+          </>
+        )}
       />
     </form>
   );

--- a/components/auth/form/ResetPasswordForm.tsx
+++ b/components/auth/form/ResetPasswordForm.tsx
@@ -2,7 +2,6 @@
 
 import PrimaryButton from "@/components/commons/button/PrimaryButton";
 import PasswordInput from "@/components/auth/input/PasswordInput";
-import Link from "next/link";
 import { ResetPasswordFormData, resetPasswordSchema } from "@/schemas/auth";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Controller, useForm } from "react-hook-form";

--- a/components/auth/form/ResetPasswordForm.tsx
+++ b/components/auth/form/ResetPasswordForm.tsx
@@ -1,58 +1,63 @@
 "use client";
 
-import { useState } from "react";
 import PrimaryButton from "@/components/commons/button/PrimaryButton";
 import PasswordInput from "@/components/auth/input/PasswordInput";
-import { AUTH_ERROR_MESSAGE } from "@/constants/authErrorMessage";
 import Link from "next/link";
+import { ResetPasswordFormData, resetPasswordSchema } from "@/schemas/auth";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Controller, useForm } from "react-hook-form";
 
 const ResetPasswordForm = () => {
-  const [formData, setFormData] = useState({
-    password: "",
+  const {
+    control,
+    handleSubmit,
+    formState: { errors, isValid, isSubmitting },
+  } = useForm<ResetPasswordFormData>({
+    resolver: zodResolver(resetPasswordSchema),
+    mode: "onChange",
+    defaultValues: {
+      password: "",
+      confirmPassword: "",
+    },
   });
-
-  const [formErrors, setFormErrors] = useState({
-    password: "",
-  });
-
-  const handleInputChange = (name: string, value: string) => {
-    setFormData((prev) => ({
-      ...prev,
-      [name]: value,
-    }));
-
-    if (name === "password") {
-      const isValidPassword =
-        /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[@$!%*?&]).{8,}$/.test(value);
-      setFormErrors((prev) => ({
-        ...prev,
-        password: isValidPassword ? "" : AUTH_ERROR_MESSAGE.PASSWORD,
-      }));
-    }
-  };
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-
-    console.log("비밀번호 변경 Form:", formData);
+  const onSubmit = async (data: ResetPasswordFormData) => {
+    console.log("비밀번호 변경 Form:", data);
+    // TODO: 비밀번호 변경 API 호출
   };
 
   return (
-    <form onSubmit={handleSubmit}>
+    <form onSubmit={handleSubmit(onSubmit)}>
       <div className="flex flex-col gap-[60px]">
         <h1 className="title2 mt-[163px] text-center">비밀번호 재설정</h1>
         <div className="mb-[43px] flex flex-col gap-[27px]">
-          <PasswordInput
+          <Controller
             name="password"
-            value={formData.password}
-            errorMessage={formErrors.password}
-            onInputChange={handleInputChange}
+            control={control}
+            render={({ field }) => (
+              <PasswordInput
+                sort="find-password"
+                isValid={!!errors.password}
+                name={field.name}
+                value={field.value}
+                errorMessage={errors.password?.message}
+                onInputChange={field.onChange}
+              />
+            )}
           />
-          <PasswordInput
-            name="password"
-            value={formData.password}
-            errorMessage={formErrors.password}
-            onInputChange={handleInputChange}
+
+          <Controller
+            name="confirmPassword"
+            control={control}
+            render={({ field }) => (
+              <PasswordInput
+                sort="find-password"
+                name={field.name}
+                isValid={!!errors.confirmPassword}
+                value={field.value}
+                errorMessage={errors.confirmPassword?.message}
+                onInputChange={field.onChange}
+              />
+            )}
           />
         </div>
       </div>
@@ -60,8 +65,7 @@ const ResetPasswordForm = () => {
         <PrimaryButton
           size="main"
           text="로그인 페이지로"
-          isActive={true}
-          onButtonClick={() => {}}
+          isActive={isValid && !isSubmitting}
         />
       </Link>
     </form>

--- a/components/auth/form/ResetPasswordForm.tsx
+++ b/components/auth/form/ResetPasswordForm.tsx
@@ -36,7 +36,7 @@ const ResetPasswordForm = () => {
             render={({ field }) => (
               <PasswordInput
                 sort="find-password"
-                isValid={!!errors.password}
+                isValid={!errors.password}
                 name={field.name}
                 value={field.value}
                 errorMessage={errors.password?.message}
@@ -52,7 +52,7 @@ const ResetPasswordForm = () => {
               <PasswordInput
                 sort="find-password"
                 name={field.name}
-                isValid={!!errors.confirmPassword}
+                isValid={!errors.confirmPassword}
                 value={field.value}
                 errorMessage={errors.confirmPassword?.message}
                 onInputChange={field.onChange}
@@ -61,13 +61,12 @@ const ResetPasswordForm = () => {
           />
         </div>
       </div>
-      <Link href="/login">
-        <PrimaryButton
-          size="main"
-          text="로그인 페이지로"
-          isActive={isValid && !isSubmitting}
-        />
-      </Link>
+      <PrimaryButton
+        type="submit"
+        size="main"
+        text="로그인 페이지로"
+        isActive={isValid && !isSubmitting}
+      />
     </form>
   );
 };

--- a/components/auth/form/SignupForm.tsx
+++ b/components/auth/form/SignupForm.tsx
@@ -80,7 +80,7 @@ const SignupForm = () => {
             render={({ field }) => (
               <>
                 <CodeInput
-                  name={field.name}
+                  sort="signup"
                   value={field.value}
                   isVerified={isVerified}
                   errorMessage={errors.code?.message}

--- a/components/auth/form/SignupForm.tsx
+++ b/components/auth/form/SignupForm.tsx
@@ -1,18 +1,13 @@
 "use client";
 
 import { useState } from "react";
-import { z } from "zod";
-import { signupSchema } from "@/schemas/auth";
+import { SignupFormData, signupSchema } from "@/schemas/auth";
 import EmailInput from "@/components/auth/input/EmailInput";
 import PasswordInput from "@/components/auth/input/PasswordInput";
 import CodeInput from "@/components/auth/input/CodeInput";
 import PrimaryButton from "@/components/commons/button/PrimaryButton";
 import { Controller, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-
-type SignupFormData = z.infer<typeof signupSchema> & {
-  confirmPassword: string;
-};
 
 const SignupForm = () => {
   // TODO: isVerified 는 “인증번호확인” API 호출 결과에 따라 true 로 설정

--- a/components/auth/form/SignupForm.tsx
+++ b/components/auth/form/SignupForm.tsx
@@ -82,6 +82,7 @@ const SignupForm = () => {
                 <CodeInput
                   sort="signup"
                   value={field.value}
+                  isValid={!!errors.code}
                   isVerified={isVerified}
                   errorMessage={errors.code?.message}
                   onInputChange={field.onChange}
@@ -105,6 +106,7 @@ const SignupForm = () => {
             <PasswordInput
               sort="signup"
               name={field.name}
+              isValid={!!errors.password}
               value={field.value}
               errorMessage={errors.password?.message}
               onInputChange={field.onChange}
@@ -118,6 +120,7 @@ const SignupForm = () => {
             <PasswordInput
               sort="signup"
               name={field.name}
+              isValid={!!errors.confirmPassword}
               value={field.value}
               errorMessage={errors.confirmPassword?.message}
               onInputChange={field.onChange}

--- a/components/auth/form/SignupForm.tsx
+++ b/components/auth/form/SignupForm.tsx
@@ -2,135 +2,138 @@
 
 import { useState } from "react";
 import { z } from "zod";
-import { signupSchema, checkPasswordsMatch } from "@/schemas/auth";
-import { useFormValidate } from "@/hooks/useFormValidate";
-
+import { signupSchema } from "@/schemas/auth";
 import EmailInput from "@/components/auth/input/EmailInput";
 import PasswordInput from "@/components/auth/input/PasswordInput";
 import CodeInput from "@/components/auth/input/CodeInput";
 import PrimaryButton from "@/components/commons/button/PrimaryButton";
+import { Controller, useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
 
 type SignupFormData = z.infer<typeof signupSchema> & {
   confirmPassword: string;
 };
 
 const SignupForm = () => {
-  const [formData, setFormData] = useState<SignupFormData>({
-    email: "",
-    code: "",
-    password: "",
-    confirmPassword: "",
+  // TODO: isVerified 는 “인증번호확인” API 호출 결과에 따라 true 로 설정
+  const [isVerified, setIsVerified] = useState(false);
+
+  const {
+    control,
+    handleSubmit,
+    formState: { errors, isValid, isSubmitting },
+  } = useForm<SignupFormData>({
+    resolver: zodResolver(signupSchema),
+    mode: "onChange",
+    defaultValues: {
+      email: "",
+      code: "",
+      password: "",
+      confirmPassword: "",
+    },
   });
 
-  const isVerified = false; // 인증번호 확인 API 성공 응답이 온 경우
-
-  const { errors: formErrors, validateField } =
-    useFormValidate<Omit<SignupFormData, "confirmPassword">>(signupSchema);
-
-  const [passwordMatchError, setPasswordMatchError] = useState<string | null>(
-    null
-  );
-
-  const handleInputChange = (name: keyof SignupFormData, value: string) => {
-    setFormData((prev) => ({
-      ...prev,
-      [name]: value,
-    }));
-
-    if (name !== "confirmPassword") {
-      validateField(name, value);
-    }
-    if (name === "confirmPassword" || name === "password") {
-      setPasswordMatchError(null); // 입력 중 오류 초기화
-    }
+  const onSubmit = (data: SignupFormData) => {
+    console.log("회원가입 시도:", data);
+    // TODO: 실제 회원가입 API 호출
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-
-    const parsed = signupSchema.safeParse({
-      email: formData.email,
-      code: formData.code,
-      password: formData.password,
-    });
-
-    if (!parsed.success) {
-      const flattened = parsed.error.flatten().fieldErrors;
-      console.log("기본 유효성 검사 실패", flattened);
-      return;
-    }
-
-    const pwError = checkPasswordsMatch(
-      formData.password,
-      formData.confirmPassword
-    );
-    if (pwError) {
-      setPasswordMatchError(pwError);
-      return;
-    }
-
-    console.log("회원가입 시도:", formData);
+  const handleRequestCode = async (email: string) => {
+    console.log("인증번호 요청:", email);
+    // TODO: 인증번호 요청 API
   };
 
-  const isFormValid =
-    Object.values(formErrors ?? {}).every((error) => !error) &&
-    !passwordMatchError &&
-    Object.values(formData).every((value) => value !== "");
+  const handleVerifyCode = async (code: string) => {
+    console.log("인증번호 확인:", code);
+    // TODO: 인증번호 확인 API → 성공 시 setIsVerified(true)
+  };
 
   return (
-    <form onSubmit={handleSubmit}>
+    <form onSubmit={handleSubmit(onSubmit)}>
       <h1 className="title2 mt-[71px] mb-[46px] text-center">회원가입</h1>
       <div className="flex flex-col gap-[23px]">
         <div>
-          <EmailInput
+          <Controller
             name="email"
-            value={formData.email}
-            errorMessage={formErrors?.email?.[0]}
-            onInputChange={handleInputChange}
+            control={control}
+            render={({ field }) => (
+              <>
+                <EmailInput
+                  isValid={!!errors.email}
+                  isVerified={isVerified}
+                  sort="signup"
+                  value={field.value}
+                  errorMessage={errors.email?.message}
+                  onInputChange={field.onChange}
+                />
+                <div className="flex justify-end">
+                  <PrimaryButton
+                    size="sub"
+                    text="인증번호받기"
+                    isActive={!!field.value && !errors.email}
+                    onButtonClick={() => handleRequestCode(field.value)}
+                  />
+                </div>
+              </>
+            )}
           />
-          <div className="flex justify-end">
-            <PrimaryButton
-              size="sub"
-              text="인증번호받기"
-              isActive={formData.email !== "" && !formErrors?.email?.[0]}
-              onButtonClick={() => {}}
-            />
-          </div>
         </div>
         <div>
-          <CodeInput
+          <Controller
             name="code"
-            value={formData.code}
-            isVerified={isVerified}
-            errorMessage={formErrors?.code?.[0]}
-            onInputChange={handleInputChange}
+            control={control}
+            render={({ field }) => (
+              <>
+                <CodeInput
+                  name={field.name}
+                  value={field.value}
+                  isVerified={isVerified}
+                  errorMessage={errors.code?.message}
+                  onInputChange={field.onChange}
+                />
+                <div className="flex justify-end">
+                  <PrimaryButton
+                    size="sub"
+                    text="인증번호확인"
+                    isActive={!!field.value && !errors.code}
+                    onButtonClick={() => handleVerifyCode(field.value)}
+                  />
+                </div>
+              </>
+            )}
           />
-          <div className="flex justify-end">
-            <PrimaryButton
-              size="sub"
-              text="인증번호확인"
-              isActive={formData.code !== "" && !formErrors?.code?.[0]}
-              onButtonClick={() => {}}
-            />
-          </div>
         </div>
-        <PasswordInput
+        <Controller
           name="password"
-          value={formData.password}
-          errorMessage={formErrors?.password?.[0]}
-          onInputChange={handleInputChange}
+          control={control}
+          render={({ field }) => (
+            <PasswordInput
+              sort="signup"
+              name={field.name}
+              value={field.value}
+              errorMessage={errors.password?.message}
+              onInputChange={field.onChange}
+            />
+          )}
         />
-        <PasswordInput
+        <Controller
           name="confirmPassword"
-          value={formData.confirmPassword}
-          errorMessage={passwordMatchError ?? undefined}
-          onInputChange={handleInputChange}
+          control={control}
+          render={({ field }) => (
+            <PasswordInput
+              sort="signup"
+              name={field.name}
+              value={field.value}
+              errorMessage={errors.confirmPassword?.message}
+              onInputChange={field.onChange}
+            />
+          )}
         />
         <PrimaryButton
           type="submit"
           size="main"
           text="다음으로"
-          isActive={isFormValid}
+          isActive={isValid && !isSubmitting && isVerified}
         />
       </div>
     </form>

--- a/components/auth/form/SignupForm.tsx
+++ b/components/auth/form/SignupForm.tsx
@@ -54,7 +54,7 @@ const SignupForm = () => {
             render={({ field }) => (
               <>
                 <EmailInput
-                  isValid={!!errors.email}
+                  isValid={!errors.email}
                   isVerified={isVerified}
                   sort="signup"
                   value={field.value}
@@ -82,7 +82,7 @@ const SignupForm = () => {
                 <CodeInput
                   sort="signup"
                   value={field.value}
-                  isValid={!!errors.code}
+                  isValid={!errors.code}
                   isVerified={isVerified}
                   errorMessage={errors.code?.message}
                   onInputChange={field.onChange}
@@ -106,7 +106,7 @@ const SignupForm = () => {
             <PasswordInput
               sort="signup"
               name={field.name}
-              isValid={!!errors.password}
+              isValid={!errors.password}
               value={field.value}
               errorMessage={errors.password?.message}
               onInputChange={field.onChange}
@@ -120,7 +120,7 @@ const SignupForm = () => {
             <PasswordInput
               sort="signup"
               name={field.name}
-              isValid={!!errors.confirmPassword}
+              isValid={!errors.confirmPassword}
               value={field.value}
               errorMessage={errors.confirmPassword?.message}
               onInputChange={field.onChange}

--- a/components/auth/form/VerifyCodeForm.tsx
+++ b/components/auth/form/VerifyCodeForm.tsx
@@ -34,6 +34,7 @@ const VerifyCodeForm = () => {
               <CodeInput
                 sort="find-password"
                 value={field.value}
+                isValid={!!errors.code}
                 isVerified={false}
                 errorMessage={errors.code?.message}
                 onInputChange={field.onChange}

--- a/components/auth/form/VerifyCodeForm.tsx
+++ b/components/auth/form/VerifyCodeForm.tsx
@@ -1,57 +1,51 @@
 "use client";
 
-import { useState } from "react";
 import PrimaryButton from "@/components/commons/button/PrimaryButton";
 import CodeInput from "@/components/auth/input/CodeInput";
-import { AUTH_ERROR_MESSAGE } from "@/constants/authErrorMessage";
+import { VerifyCodeFormData, verifyCodeSchema } from "@/schemas/auth";
+import { Controller, useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
 
 const VerifyCodeForm = () => {
-  const [formData, setFormData] = useState({
-    code: "",
+  const {
+    control,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<VerifyCodeFormData>({
+    resolver: zodResolver(verifyCodeSchema),
+    mode: "onChange",
+    defaultValues: { code: "" },
   });
 
-  const [formErrors, setFormErrors] = useState({
-    code: "",
-  });
-
-  const handleInputChange = (name: string, value: string) => {
-    setFormData((prev) => ({
-      ...prev,
-      [name]: value,
-    }));
-
-    if (name === "code") {
-      const isValidCode = /^\d{6}$/.test(value);
-      setFormErrors((prev) => ({
-        ...prev,
-        code: isValidCode ? "" : AUTH_ERROR_MESSAGE.CODE,
-      }));
-    }
-  };
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-
-    console.log("인증번호 확인 Form:", formData);
+  const onSubmit = (data: VerifyCodeFormData) => {
+    console.log("인증번호 확인 Form:", data);
+    // TODO: 인증번호 확인 API 호출
   };
 
   return (
-    <form onSubmit={handleSubmit}>
-      <div className="mb-[37px] flex flex-col gap-[78px]">
-        <h1 className="title2 mt-[163px] text-center">비밀번호 찾기</h1>
-        <CodeInput
-          name="code"
-          isVerified={false}
-          value={formData.code}
-          errorMessage={formErrors.code}
-          onInputChange={handleInputChange}
-        />
-      </div>
-      <PrimaryButton
-        size="main"
-        text="인증번호 확인"
-        isActive={false}
-        onButtonClick={() => {}}
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <Controller
+        name="code"
+        control={control}
+        render={({ field }) => (
+          <>
+            <div className="mb-[37px] flex flex-col gap-[78px]">
+              <h1 className="title2 mt-[163px] text-center">비밀번호 찾기</h1>
+              <CodeInput
+                sort="find-password"
+                value={field.value}
+                isVerified={false}
+                errorMessage={errors.code?.message}
+                onInputChange={field.onChange}
+              />
+            </div>
+            <PrimaryButton
+              size="main"
+              text="인증번호 확인"
+              isActive={!errors.code}
+            />
+          </>
+        )}
       />
     </form>
   );

--- a/components/auth/form/VerifyCodeForm.tsx
+++ b/components/auth/form/VerifyCodeForm.tsx
@@ -10,7 +10,7 @@ const VerifyCodeForm = () => {
   const {
     control,
     handleSubmit,
-    formState: { errors },
+    formState: { errors, isValid, isSubmitting },
   } = useForm<VerifyCodeFormData>({
     resolver: zodResolver(verifyCodeSchema),
     mode: "onChange",
@@ -34,7 +34,7 @@ const VerifyCodeForm = () => {
               <CodeInput
                 sort="find-password"
                 value={field.value}
-                isValid={!!errors.code}
+                isValid={!errors.code}
                 isVerified={false}
                 errorMessage={errors.code?.message}
                 onInputChange={field.onChange}
@@ -43,7 +43,7 @@ const VerifyCodeForm = () => {
             <PrimaryButton
               size="main"
               text="인증번호 확인"
-              isActive={!errors.code}
+              isActive={isValid && !isSubmitting}
             />
           </>
         )}

--- a/components/auth/input/CodeInput.tsx
+++ b/components/auth/input/CodeInput.tsx
@@ -3,13 +3,14 @@
 import InputWrapper from "@/components/auth/input/InputWrapper";
 import { formatSecondsToMMSS } from "@/utils/time";
 import { useCountdown } from "@/hooks/useCountdown";
+import { AUTH_ERROR_MESSAGE } from "@/constants/authErrorMessage";
 
 interface CodeInputProps {
   name: "code";
   value: string;
   isVerified: boolean;
   errorMessage?: string;
-  onInputChange: (name: CodeInputProps["name"], value: string) => void;
+  onInputChange: (value: string) => void;
 }
 
 const CodeInput = ({
@@ -24,18 +25,18 @@ const CodeInput = ({
   const { timeLeft, setResendTrigger } = useCountdown(DURATION_IN_SECONDS);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    onInputChange(name, e.target.value);
+    onInputChange(e.target.value);
   };
 
   const handleResendCode = () => {
-    onInputChange(name, "");
     setResendTrigger((prev) => prev + 1);
   };
 
   return (
     <InputWrapper
+      sort="signup"
       error={value !== "" && !!errorMessage}
-      helperText={errorMessage || "* 인증번호 6글자를 입력해주세요"}
+      helperText={errorMessage || (value === "" ? AUTH_ERROR_MESSAGE.CODE : "")}
       isVerified={isVerified}
     >
       <input

--- a/components/auth/input/CodeInput.tsx
+++ b/components/auth/input/CodeInput.tsx
@@ -8,6 +8,7 @@ import { AUTH_ERROR_MESSAGE } from "@/constants/authErrorMessage";
 interface CodeInputProps {
   value: string;
   isVerified: boolean;
+  isValid: boolean;
   errorMessage?: string;
   onInputChange: (value: string) => void;
   sort: "login" | "signup" | "find-password";
@@ -17,6 +18,7 @@ const CodeInput = ({
   sort,
   errorMessage,
   value,
+  isValid,
   isVerified,
   onInputChange,
 }: CodeInputProps) => {
@@ -35,7 +37,7 @@ const CodeInput = ({
   return (
     <InputWrapper
       sort={sort}
-      error={value !== "" && !!errorMessage}
+      error={isValid}
       helperText={errorMessage || (value === "" ? AUTH_ERROR_MESSAGE.CODE : "")}
       isVerified={isVerified}
     >

--- a/components/auth/input/CodeInput.tsx
+++ b/components/auth/input/CodeInput.tsx
@@ -37,7 +37,7 @@ const CodeInput = ({
   return (
     <InputWrapper
       sort={sort}
-      error={isValid}
+      error={!isValid}
       helperText={errorMessage || (value === "" ? AUTH_ERROR_MESSAGE.CODE : "")}
       isVerified={isVerified}
     >

--- a/components/auth/input/CodeInput.tsx
+++ b/components/auth/input/CodeInput.tsx
@@ -6,15 +6,15 @@ import { useCountdown } from "@/hooks/useCountdown";
 import { AUTH_ERROR_MESSAGE } from "@/constants/authErrorMessage";
 
 interface CodeInputProps {
-  name: "code";
   value: string;
   isVerified: boolean;
   errorMessage?: string;
   onInputChange: (value: string) => void;
+  sort: "login" | "signup" | "find-password";
 }
 
 const CodeInput = ({
-  name,
+  sort,
   errorMessage,
   value,
   isVerified,
@@ -34,7 +34,7 @@ const CodeInput = ({
 
   return (
     <InputWrapper
-      sort="signup"
+      sort={sort}
       error={value !== "" && !!errorMessage}
       helperText={errorMessage || (value === "" ? AUTH_ERROR_MESSAGE.CODE : "")}
       isVerified={isVerified}

--- a/components/auth/input/EmailInput.tsx
+++ b/components/auth/input/EmailInput.tsx
@@ -7,7 +7,7 @@ interface EmailInputProps {
   errorMessage?: string;
   value: string;
   onInputChange: (value: string) => void;
-  sort: "login" | "signup";
+  sort: "login" | "signup" | "find-password";
 }
 
 const EmailInput = ({

--- a/components/auth/input/EmailInput.tsx
+++ b/components/auth/input/EmailInput.tsx
@@ -2,35 +2,38 @@ import InputWrapper from "@/components/auth/input/InputWrapper";
 import { AUTH_ERROR_MESSAGE } from "@/constants/authErrorMessage";
 
 interface EmailInputProps {
-  name: "email";
+  isValid: boolean;
+  isVerified?: boolean;
   errorMessage?: string;
   value: string;
-  onInputChange: (name: EmailInputProps["name"], value: string) => void;
+  onInputChange: (value: string) => void;
+  sort: "login" | "signup";
 }
 
 const EmailInput = ({
-  name,
+  isValid,
+  isVerified,
   errorMessage,
   value,
   onInputChange,
+  sort,
 }: EmailInputProps) => {
-  const isVerified = false;
-
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    onInputChange(name, e.target.value);
+    onInputChange(e.target.value);
   };
 
   const handleClearClick = () => {
-    onInputChange(name, "");
+    onInputChange("");
   };
 
   return (
     <InputWrapper
-      error={value !== "" && !!errorMessage}
+      error={isValid}
       helperText={
         errorMessage || (value === "" ? AUTH_ERROR_MESSAGE.EMAIL : "")
       }
       isVerified={isVerified}
+      sort={sort}
     >
       <input
         className="subhead1 h-[24px] w-full"

--- a/components/auth/input/EmailInput.tsx
+++ b/components/auth/input/EmailInput.tsx
@@ -28,7 +28,7 @@ const EmailInput = ({
 
   return (
     <InputWrapper
-      error={isValid}
+      error={!isValid}
       helperText={
         errorMessage || (value === "" ? AUTH_ERROR_MESSAGE.EMAIL : "")
       }

--- a/components/auth/input/InputWrapper.tsx
+++ b/components/auth/input/InputWrapper.tsx
@@ -24,7 +24,7 @@ const InputWrapper = ({
       <div className={containerClass}>{children}</div>
       {((sort === "login" && error) ||
         sort === "signup" ||
-        "find-password") && (
+        sort === "find-password") && (
         <p
           role={error ? "alert" : "note"}
           aria-live={error ? "polite" : undefined}

--- a/components/auth/input/InputWrapper.tsx
+++ b/components/auth/input/InputWrapper.tsx
@@ -3,6 +3,7 @@ interface InputWrapperProps {
   helperText?: string;
   children: React.ReactNode;
   isVerified?: boolean;
+  sort: "login" | "signup";
 }
 
 const InputWrapper = ({
@@ -10,6 +11,7 @@ const InputWrapper = ({
   helperText = "",
   children,
   isVerified,
+  sort,
 }: InputWrapperProps) => {
   const containerClass = `
     flex w-full items-center gap-[6px] rounded-[6px] border-1 py-[12px] pr-[12px] pl-[20px]
@@ -20,15 +22,17 @@ const InputWrapper = ({
   return (
     <div>
       <div className={containerClass}>{children}</div>
-      <p
-        role={error ? "alert" : "note"}
-        aria-live={error ? "polite" : undefined}
-        className={`${
-          error ? "text-primary-red" : "text-primary-darkGray"
-        } footnote ml-[20px]`}
-      >
-        {helperText}
-      </p>
+      {((sort === "login" && error) || sort === "signup") && (
+        <p
+          role={error ? "alert" : "note"}
+          aria-live={error ? "polite" : undefined}
+          className={`${
+            error ? "text-primary-red" : "text-primary-darkGray"
+          } footnote ml-[20px]`}
+        >
+          {helperText}
+        </p>
+      )}
     </div>
   );
 };

--- a/components/auth/input/InputWrapper.tsx
+++ b/components/auth/input/InputWrapper.tsx
@@ -3,7 +3,7 @@ interface InputWrapperProps {
   helperText?: string;
   children: React.ReactNode;
   isVerified?: boolean;
-  sort: "login" | "signup";
+  sort: "login" | "signup" | "find-password";
 }
 
 const InputWrapper = ({
@@ -22,7 +22,9 @@ const InputWrapper = ({
   return (
     <div>
       <div className={containerClass}>{children}</div>
-      {((sort === "login" && error) || sort === "signup") && (
+      {((sort === "login" && error) ||
+        sort === "signup" ||
+        "find-password") && (
         <p
           role={error ? "alert" : "note"}
           aria-live={error ? "polite" : undefined}

--- a/components/auth/input/PasswordInput.tsx
+++ b/components/auth/input/PasswordInput.tsx
@@ -31,7 +31,7 @@ const PasswordInput = <NameType extends string>({
 
   return (
     <InputWrapper
-      error={isValid}
+      error={!isValid}
       helperText={
         errorMessage || (value === "" ? AUTH_ERROR_MESSAGE.PASSWORD : "")
       }

--- a/components/auth/input/PasswordInput.tsx
+++ b/components/auth/input/PasswordInput.tsx
@@ -8,7 +8,8 @@ interface PasswordInputProps<NameType extends string> {
   name: NameType;
   errorMessage?: string;
   value: string;
-  onInputChange: (name: NameType, value: string) => void;
+  onInputChange: (value: string) => void;
+  sort: "login" | "signup";
 }
 
 const PasswordInput = <NameType extends string>({
@@ -16,20 +17,25 @@ const PasswordInput = <NameType extends string>({
   errorMessage,
   value,
   onInputChange,
+  sort,
 }: PasswordInputProps<NameType>) => {
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    onInputChange(name, e.target.value);
+    onInputChange(e.target.value);
   };
 
   const placeHolder = name === "password" ? "비밀번호" : "비밀번호 확인";
-  const helperText = name === "password" ? AUTH_ERROR_MESSAGE.PASSWORD : "";
 
   return (
     <InputWrapper
       error={value !== "" && !!errorMessage}
-      helperText={errorMessage || (value === "" ? helperText : "")}
+      helperText={
+        name === "password"
+          ? errorMessage || (value === "" ? AUTH_ERROR_MESSAGE.PASSWORD : "")
+          : ""
+      }
+      sort={sort}
     >
       <input
         className="subhead1 h-[24px] w-full"

--- a/components/auth/input/PasswordInput.tsx
+++ b/components/auth/input/PasswordInput.tsx
@@ -6,15 +6,17 @@ import { AUTH_ERROR_MESSAGE } from "@/constants/authErrorMessage";
 
 interface PasswordInputProps<NameType extends string> {
   name: NameType;
+  isValid: boolean;
   errorMessage?: string;
   value: string;
   onInputChange: (value: string) => void;
-  sort: "login" | "signup";
+  sort: "login" | "signup" | "find-password";
 }
 
 const PasswordInput = <NameType extends string>({
   name,
   errorMessage,
+  isValid,
   value,
   onInputChange,
   sort,
@@ -29,11 +31,9 @@ const PasswordInput = <NameType extends string>({
 
   return (
     <InputWrapper
-      error={value !== "" && !!errorMessage}
+      error={isValid}
       helperText={
-        name === "password"
-          ? errorMessage || (value === "" ? AUTH_ERROR_MESSAGE.PASSWORD : "")
-          : ""
+        errorMessage || (value === "" ? AUTH_ERROR_MESSAGE.PASSWORD : "")
       }
       sort={sort}
     >

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "tosiltosil",
       "version": "0.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.1.1",
         "@svgr/webpack": "^8.1.0",
         "@tanstack/react-query": "^5.76.1",
         "jotai": "^2.12.4",
@@ -2301,6 +2302,18 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.1.1.tgz",
+      "integrity": "sha512-J/NVING3LMAEvexJkyTLjruSm7aOFx7QX21pzkiJfMoNG0wl5aFEjLTl7ay7IQb9EWY6AkrBy7tHL2Alijpdcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -3449,6 +3462,12 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.11.0.tgz",
       "integrity": "sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@storybook/addon-a11y": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "chromatic": "chromatic --exit-zero-on-changes"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.1.1",
     "@svgr/webpack": "^8.1.0",
     "@tanstack/react-query": "^5.76.1",
     "jotai": "^2.12.4",

--- a/schemas/auth.ts
+++ b/schemas/auth.ts
@@ -1,7 +1,5 @@
 import { z } from "zod";
 
-export type LoginFormData = z.infer<typeof loginSchema>;
-
 export const loginSchema = z.object({
   email: z.string().email({
     message: "이메일 양식에 맞지 않습니다. 다시 입력해주세요.",
@@ -41,3 +39,15 @@ export const signupSchema = z
     message: "입력하신 비밀번호와 일치하지 않습니다.",
     path: ["confirmPassword"],
   });
+
+export const requestCodeSchema = z.object({
+  email: z
+    .string({ required_error: "이메일을 입력해주세요" })
+    .email("유효한 이메일 형식이 아닙니다"),
+});
+
+export type RequestCodeFormData = z.infer<typeof requestCodeSchema>;
+export type LoginFormData = z.infer<typeof loginSchema>;
+export type SignupFormData = z.infer<typeof signupSchema> & {
+  confirmPassword: string;
+};

--- a/schemas/auth.ts
+++ b/schemas/auth.ts
@@ -30,10 +30,7 @@ export const signupSchema = z
       }),
   })
   .extend({
-    confirmPassword: z.string({
-      required_error:
-        "영문,숫자,특수문자를 포함하여 8글자 이상으로 입력해주세요",
-    }),
+    confirmPassword: z.string(),
   })
   .refine((data) => data.password === data.confirmPassword, {
     message: "입력하신 비밀번호와 일치하지 않습니다.",
@@ -41,20 +38,30 @@ export const signupSchema = z
   });
 
 export const requestCodeSchema = z.object({
-  email: z
-    .string({ required_error: "이메일을 입력해주세요" })
-    .email("유효한 이메일 형식이 아닙니다"),
+  email: z.string().email("유효한 이메일 형식이 아닙니다"),
 });
 
 export const verifyCodeSchema = z.object({
-  code: z
-    .string({ required_error: "인증번호를 입력해주세요" })
-    .regex(/^\d{6}$/, "인증번호는 숫자 6자리여야 합니다"),
+  code: z.string().regex(/^\d{6}$/, "인증번호는 숫자 6자리여야 합니다"),
 });
 
-export type VerifyCodeFormData = z.infer<typeof verifyCodeSchema>;
-export type RequestCodeFormData = z.infer<typeof requestCodeSchema>;
+export const resetPasswordSchema = z
+  .object({
+    password: z
+      .string()
+      .regex(
+        /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/,
+        "영문,숫자,특수문자를 포함하여 8글자 이상으로 입력해주세요"
+      ),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "입력하신 비밀번호와 일치하지 않습니다.",
+    path: ["confirmPassword"],
+  });
+
 export type LoginFormData = z.infer<typeof loginSchema>;
-export type SignupFormData = z.infer<typeof signupSchema> & {
-  confirmPassword: string;
-};
+export type SignupFormData = z.infer<typeof signupSchema>;
+export type RequestCodeFormData = z.infer<typeof requestCodeSchema>;
+export type VerifyCodeFormData = z.infer<typeof verifyCodeSchema>;
+export type ResetPasswordFormData = z.infer<typeof resetPasswordSchema>;

--- a/schemas/auth.ts
+++ b/schemas/auth.ts
@@ -46,6 +46,13 @@ export const requestCodeSchema = z.object({
     .email("유효한 이메일 형식이 아닙니다"),
 });
 
+export const verifyCodeSchema = z.object({
+  code: z
+    .string({ required_error: "인증번호를 입력해주세요" })
+    .regex(/^\d{6}$/, "인증번호는 숫자 6자리여야 합니다"),
+});
+
+export type VerifyCodeFormData = z.infer<typeof verifyCodeSchema>;
 export type RequestCodeFormData = z.infer<typeof requestCodeSchema>;
 export type LoginFormData = z.infer<typeof loginSchema>;
 export type SignupFormData = z.infer<typeof signupSchema> & {

--- a/schemas/auth.ts
+++ b/schemas/auth.ts
@@ -1,35 +1,16 @@
 import { z } from "zod";
+import { emailSchema, codeSchema, passwordSchema } from "./validators";
 
 export const loginSchema = z.object({
-  email: z.string().email({
-    message: "이메일 양식에 맞지 않습니다. 다시 입력해주세요.",
-  }),
-  password: z
-    .string()
-    .min(8, {
-      message: "영문,숫자,특수문자를 포함하여 8글자 이상으로 입력해주세요",
-    })
-    .regex(/^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/, {
-      message: "영문,숫자,특수문자를 포함하여 8글자 이상으로 입력해주세요",
-    }),
+  email: emailSchema,
+  password: passwordSchema,
 });
 
 export const signupSchema = z
   .object({
-    email: z.string().email({ message: "올바른 이메일 형식을 입력해주세요." }),
-    code: z
-      .string()
-      .regex(/^\d{6}$/, { message: "숫자 6자리로 입력해주세요." }),
-    password: z
-      .string()
-      .min(8, {
-        message: "영문,숫자,특수문자를 포함하여 8글자 이상으로 입력해주세요",
-      })
-      .regex(/^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/, {
-        message: "영문,숫자,특수문자를 포함하여 8글자 이상으로 입력해주세요",
-      }),
-  })
-  .extend({
+    email: emailSchema,
+    code: codeSchema,
+    password: passwordSchema,
     confirmPassword: z.string(),
   })
   .refine((data) => data.password === data.confirmPassword, {
@@ -38,21 +19,16 @@ export const signupSchema = z
   });
 
 export const requestCodeSchema = z.object({
-  email: z.string().email("유효한 이메일 형식이 아닙니다"),
+  email: emailSchema,
 });
 
 export const verifyCodeSchema = z.object({
-  code: z.string().regex(/^\d{6}$/, "인증번호는 숫자 6자리여야 합니다"),
+  code: codeSchema,
 });
 
 export const resetPasswordSchema = z
   .object({
-    password: z
-      .string()
-      .regex(
-        /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/,
-        "영문,숫자,특수문자를 포함하여 8글자 이상으로 입력해주세요"
-      ),
+    password: passwordSchema,
     confirmPassword: z.string(),
   })
   .refine((data) => data.password === data.confirmPassword, {

--- a/schemas/auth.ts
+++ b/schemas/auth.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+export type LoginFormData = z.infer<typeof loginSchema>;
+
 export const loginSchema = z.object({
   email: z.string().email({
     message: "이메일 양식에 맞지 않습니다. 다시 입력해주세요.",
@@ -7,36 +9,35 @@ export const loginSchema = z.object({
   password: z
     .string()
     .min(8, {
-      message:
-        "영어, 숫자, 특수문자를 모두 포함하여 8글자 이상으로 입력해주세요.",
+      message: "영문,숫자,특수문자를 포함하여 8글자 이상으로 입력해주세요",
     })
     .regex(/^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/, {
-      message:
-        "영어, 숫자, 특수문자를 모두 포함하여 8글자 이상으로 입력해주세요.",
+      message: "영문,숫자,특수문자를 포함하여 8글자 이상으로 입력해주세요",
     }),
 });
 
-export const signupSchema = z.object({
-  email: z.string().email({ message: "올바른 이메일 형식을 입력해주세요." }),
-  code: z.string().regex(/^\d{6}$/, { message: "숫자 6자리로 입력해주세요." }),
-  password: z
-    .string()
-    .min(8, {
-      message:
-        "영어, 숫자, 특수문자를 모두 포함하여 8글자 이상으로 입력해주세요.",
-    })
-    .regex(/^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/, {
-      message:
-        "영어, 숫자, 특수문자를 모두 포함하여 8글자 이상으로 입력해주세요.",
+export const signupSchema = z
+  .object({
+    email: z.string().email({ message: "올바른 이메일 형식을 입력해주세요." }),
+    code: z
+      .string()
+      .regex(/^\d{6}$/, { message: "숫자 6자리로 입력해주세요." }),
+    password: z
+      .string()
+      .min(8, {
+        message: "영문,숫자,특수문자를 포함하여 8글자 이상으로 입력해주세요",
+      })
+      .regex(/^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/, {
+        message: "영문,숫자,특수문자를 포함하여 8글자 이상으로 입력해주세요",
+      }),
+  })
+  .extend({
+    confirmPassword: z.string({
+      required_error:
+        "영문,숫자,특수문자를 포함하여 8글자 이상으로 입력해주세요",
     }),
-});
-
-export function checkPasswordsMatch(
-  password: string,
-  confirmPassword: string
-): string | null {
-  if (password !== confirmPassword) {
-    return "입력하신 비밀번호와 일치하지 않습니다. 다시 입력해주세요";
-  }
-  return null;
-}
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "입력하신 비밀번호와 일치하지 않습니다.",
+    path: ["confirmPassword"],
+  });

--- a/schemas/validators.ts
+++ b/schemas/validators.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+export const emailSchema = z
+  .string()
+  .email({ message: "유효한 이메일 형식이 아닙니다." });
+
+export const codeSchema = z
+  .string()
+  .length(6, { message: "인증번호는 숫자 6자리여야 합니다." });
+
+const passwordErrorMsg =
+  "영문, 숫자, 특수문자를 포함하여 8자 이상 입력해주세요.";
+
+export const passwordSchema = z
+  .string()
+  .min(8, { message: passwordErrorMsg })
+  .regex(/^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&]).{8,}$/, {
+    message: passwordErrorMsg,
+  });

--- a/schemas/validators.ts
+++ b/schemas/validators.ts
@@ -6,7 +6,7 @@ export const emailSchema = z
 
 export const codeSchema = z
   .string()
-  .length(6, { message: "인증번호는 숫자 6자리여야 합니다." });
+  .regex(/^\d{6}$/, { message: "인증번호는 숫자 6자리여야 합니다." });
 
 const passwordErrorMsg =
   "영문, 숫자, 특수문자를 포함하여 8자 이상 입력해주세요.";


### PR DESCRIPTION
## 📄 Summary

>
- react-hook-form을 사용하여  리렌더링 개선 
  - Zod 스키마와 zodResolver를 결합해 각 단계별 폼(email, 인증번호, 비밀번호 재설정 등)의 유효성 검사를 진행 
  - useForm + Controller로 커스텀 입력 컴포넌트(EmailInput, CodeInput, PasswordInput) 바인딩
  - schema 및 validation 중복 개선 
  - 로그인, 회원가입, 비밀번호 찾기에서의 input의 동작이 달라서 sort를 사용하여 구분 

- 비밀번호 찾기 경로 수정 
  - 비밀번호찾기 같은경우 이메일 입력, 인증번호 입력, 비밀번호 입력 순서대로 진행하기 때문에 각각의 페이지로 분리하였고
     현재 state로 페이지를 구분하는 것이 맞지않다고 판단하여 수정했습니다. 

## 🙋🏻 More

>


close #21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - 비밀번호 찾기 인증 코드 확인 페이지가 추가되었습니다.

- **Refactor**
    - 로그인, 회원가입, 비밀번호 찾기 관련 폼이 react-hook-form과 Zod 기반 검증 방식으로 통합되어 입력 및 검증 경험이 개선되었습니다.
    - 입력 컴포넌트(이메일, 비밀번호, 인증코드)의 props 구조와 검증 로직이 단순화되고 일관성 있게 변경되었습니다.
    - 비밀번호 찾기 페이지 내 인증 코드 요청 및 검증 흐름이 단순화되고 분리되었습니다.
    - 인증 관련 스키마와 검증 로직이 재사용 가능한 구조로 리팩터링되었습니다.

- **Chores**
    - 폼 검증을 위한 @hookform/resolvers 패키지가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->